### PR TITLE
Remove ESP32 conflicting type error

### DIFF
--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -220,7 +220,7 @@ void ClickEncoder::service(void)
     }
   
     if (doubleClickTicks > 0) {
-      doubleClickTicks -= min(millisSinceLastCheck, doubleClickTicks);
+      doubleClickTicks -= min(uint16_t(millisSinceLastCheck), doubleClickTicks);
       if (doubleClickTicks == 0) {
         button = Clicked;
       }


### PR DESCRIPTION
Removes the type comparison error on min() for the Adafruit Feather ESP32 board:
deduced conflicting types for parameter 'const _Tp' ('long unsigned int' and 'uint16_t' {aka 'short unsigned int'})